### PR TITLE
Package each function separately to reduce function size

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: javascript
+    directory: /
+    update_schedule: weekly
+    ignored_updates:
+      - match:
+          dependency_name: aws-sdk

--- a/package-lock.json
+++ b/package-lock.json
@@ -12839,12 +12839,6 @@
         }
       }
     },
-    "webpack-node-externals": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
-      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
-      "dev": true
-    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,9 +2286,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.517.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.517.0.tgz",
-      "integrity": "sha512-CX0b+8StmzAGQOP5eoBYJExpjTdPeVPig3NC4crq71/0LkrIDGcc6ekVEl0Rx23WTyGDzExeDD1be1HvQNwHdA==",
+      "version": "2.488.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.488.0.tgz",
+      "integrity": "sha512-9AP48tyF1E5+x1CKeiRlj0Sv1YF7KI0BdSW9JP8x3ClhPWNUHjDYNH2OwsALuG1BloeY2ZigYqfI2fB7g3rNHQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "serverless-offline": "^5.10.1",
     "serverless-plugin-stage-variables": "^1.9.5",
     "serverless-webpack": "^5.3.1",
-    "webpack": "^4.39.2",
-    "webpack-node-externals": "^1.7.2"
+    "webpack": "^4.39.2"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --watch src"
   },
   "dependencies": {
-    "aws-sdk": "^2.517.0"
+    "aws-sdk": "2.488.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,10 +20,6 @@ resources:
   - ${file(src/resources/apigateway.yml)}
   - ${file(src/resources/iam.yml)}
 
-custom:
-  webpack:
-    includeModules: true
-
 # Serverless plugins. The "stage-variables" plugin is required to allow us to
 # customise the API Gateway stage that gets created automatically by Serverless.
 plugins:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,10 @@
-const nodeExternals = require('webpack-node-externals');
 const slsw = require('serverless-webpack');
 
 module.exports = {
   entry: slsw.lib.entries,
   target: 'node',
   mode: 'production',
-  externals: [nodeExternals()],
+  externals: [{ 'aws-sdk': 'commonjs aws-sdk' }],
   module: {
     rules: [
       {


### PR DESCRIPTION
- [x] All functions now individually packaged
- [x] `aws-sdk` removed from bundle as provided by Lambda Runtime
- [x] Fix `aws-sdk` to 2.488.0 as that is the version provided by AWS (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
- [x] Add a Dependabot config so it doesn't pester to update `aws-sdk`

On another Orange Jellyfish project this reduced each function bundle to under 1% of its previous size.