### PR TITLE
Use Node 10.16.3 for Lambdas

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8.10"
+          "node": "10.16.3"
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "start": "serverless offline start",
     "test": "jest --watch src"
   },
+  "engines": {
+    "node": "10.16.3"
+  },
   "dependencies": {
     "aws-sdk": "^2.517.0"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ frameworkVersion: '=1.50.0'
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 # Lambda function definitions. Each function defines itself in a separate YAML
 # file that resides alongside the function implementation. Unfortunately we have


### PR DESCRIPTION
- [x] Use Node 10.16.3 as that's the version [AWS currently have for `nodejs10.x`](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html):
<img width="710" alt="image" src="https://user-images.githubusercontent.com/1379888/64855150-2d0e1400-d617-11e9-9df4-6a40477aeecc.png">