### PR TITLE
Include Node version in default function response

### DIFF
--- a/src/functions/hello/index.js
+++ b/src/functions/hello/index.js
@@ -8,6 +8,7 @@ export const hello = async function hello(event) {
     body: JSON.stringify({
       message: 'Go Serverless v1.0! Your function executed successfully!',
       input: event,
+      version: process.version,
     }),
   };
 


### PR DESCRIPTION
This makes it easy to check the version of Node running in the Lambda
which is useful to ensure your local dev environment matches the remote
environment.